### PR TITLE
Update AdbDevice.java

### DIFF
--- a/java/src/xuxu/autotest/AdbDevice.java
+++ b/java/src/xuxu/autotest/AdbDevice.java
@@ -16,7 +16,7 @@ import xuxu.autotest.element.Element;
  */
 public class AdbDevice {
 	public AdbDevice() {
-		ShellUtils.cmd("adb wait-for-device");
+		ShellUtils.cmd("wait-for-device");
 	}
 
 	/**


### PR DESCRIPTION
line 19: ShellUtils.cmd("adb wait-for-device");  adb is redundant.
